### PR TITLE
created line 56 and 63 in helpers,py

### DIFF
--- a/src/dtumathtools/helpers.py
+++ b/src/dtumathtools/helpers.py
@@ -41,17 +41,6 @@ def hessian(expr, var=None):
 
 def _extract_field_vars(V, var, namefunc):
     return _extract_vars(V) if var is None else var
-    var = _extract_vars(V) if var is None else var
-    if len(var) < 3 and all([f in ["x", "y", "z"] for f in var]):
-        x, y, z = symbols("x,y,z")
-        var = [x, y, z]
-    elif len(var) != 3:
-        raise Exception(
-            f"{namefunc} found the variables {var}, but expected 3 variables. \n" +
-            f"Try specifying the variables using the 'var' keyword argument like: {namefunc}(V, var=(x,y,z))."
-        )
-    return var
-
 
 def div(V, var=None):
     var = _extract_field_vars(V, var, "div")

--- a/src/dtumathtools/helpers.py
+++ b/src/dtumathtools/helpers.py
@@ -40,6 +40,7 @@ def hessian(expr, var=None):
 
 
 def _extract_field_vars(V, var, namefunc):
+    return _extract_vars(V) if var is None else var
     var = _extract_vars(V) if var is None else var
     if len(var) < 3 and all([f in ["x", "y", "z"] for f in var]):
         x, y, z = symbols("x,y,z")
@@ -53,15 +54,12 @@ def _extract_field_vars(V, var, namefunc):
 
 
 def div(V, var=None):
-    if var is None:
-        var = _extract_field_vars(V, var, "div")
-
+    var = _extract_field_vars(V, var, "div")
     return sum([V[i].diff(f) for i, f in enumerate(var)])
 
 
 def rot(V, var=None):
-    if var is None:
-        var = _extract_field_vars(V, var, "rot")
+    var = _extract_field_vars(V, var, "rot")
 
     return Matrix(
         [
@@ -78,9 +76,14 @@ if __name__ == "__main__":
     V = Matrix([-y, x, 1])
     print(div(U))
     print(div(V))
-
-    ## Example 2
-    U = Matrix([x, y, z])
-    V = Matrix([-y, x, 1])
     print(div(U, var=[x, y, z]))
     print(div(V, var=[x, y]))
+
+    ## Example 2
+    u, v, w = symbols("u v w")
+    W = Matrix([u, v, w])
+    X = Matrix([-v, u, 1])
+    print(div(W))
+    print(div(X))
+    print(div(W, var=[u, v, w]))
+    print(div(X, var=[u, v]))

--- a/src/dtumathtools/helpers.py
+++ b/src/dtumathtools/helpers.py
@@ -42,6 +42,7 @@ def hessian(expr, var=None):
 def _extract_field_vars(V, var, namefunc):
     return _extract_vars(V) if var is None else var
 
+
 def div(V, var=None):
     var = _extract_field_vars(V, var, "div")
     return sum([V[i].diff(f) for i, f in enumerate(var)])

--- a/src/dtumathtools/helpers.py
+++ b/src/dtumathtools/helpers.py
@@ -53,13 +53,15 @@ def _extract_field_vars(V, var, namefunc):
 
 
 def div(V, var=None):
-    var = _extract_field_vars(V, var, "div")
+    if var is None:
+        var = _extract_field_vars(V, var, "div")
 
     return sum([V[i].diff(f) for i, f in enumerate(var)])
 
 
 def rot(V, var=None):
-    var = _extract_field_vars(V, var, "rot")
+    if var is None:
+        var = _extract_field_vars(V, var, "rot")
 
     return Matrix(
         [

--- a/src/dtumathtools/helpers.py
+++ b/src/dtumathtools/helpers.py
@@ -46,8 +46,8 @@ def _extract_field_vars(V, var, namefunc):
         var = [x, y, z]
     elif len(var) != 3:
         raise Exception(
-            f"{namefunc} found the variables {var}, but expected 3 variables. \
-            Try specifying the variables using the 'var' keyword argument like: {namefunc}(V, var=(x,y,z))."
+            f"{namefunc} found the variables {var}, but expected 3 variables. \n" +
+            f"Try specifying the variables using the 'var' keyword argument like: {namefunc}(V, var=(x,y,z))."
         )
     return var
 
@@ -70,3 +70,17 @@ def rot(V, var=None):
             V[1].diff(var[0]) - V[0].diff(var[1]),
         ]
     )
+
+if __name__ == "__main__":
+    x, y, z = symbols("x y z")
+    ## Example 1
+    U = Matrix([x, y, z])
+    V = Matrix([-y, x, 1])
+    print(div(U))
+    print(div(V))
+
+    ## Example 2
+    U = Matrix([x, y, z])
+    V = Matrix([-y, x, 1])
+    print(div(U, var=[x, y, z]))
+    print(div(V, var=[x, y]))


### PR DESCRIPTION
Der er et problem med, at hvis man har en 3 dim. gradientfelt, som man gerne vil finde div og rot på, så leder den efter både x, y, z. Dermed får man en error.
Dette er fikset ved, at hvis man har givet variable, differentierer den i forhold til de variable, og den finder ikke nye variable ved vha. funktionen _extract_field_vars.
Denne fejl kan replikeres ved at skrive:

```
from dtumathtools import dtutools, dtuplot
from sympy import *
x, y, z = symbols("x y z")
U = Matrix([x, y, z])
V = Matrix([-y, x, 1])
dtutools.div(U)
dtutools.div(V)
```

Dermed opstår fejlen, når ```dtutools.div(V)``` skrives.